### PR TITLE
fix: missing fileio extension functions

### DIFF
--- a/make.ts
+++ b/make.ts
@@ -25,8 +25,10 @@ if (!$.fs.existsSync("sqlite-regex")) {
 }
 await $`cd sqlite-regex && make static-release`;
 
+// Note: Fixing a release as we're patching the sqlean fileio default initialization function name in shell.c
 if (!$.fs.existsSync("sqlean")) {
   await $`git clone https://github.com/nalgeon/sqlean`;
+  await $`cd sqlean && git checkout tags/0.21.8 && git checkout -b release_0_21_8 tags/0.21.8`
 }
 
 // Note: manually downloaded the cwalk zip and unzip in sqlite-path dir.

--- a/patch/sqlite3_fileio_init_resolve.patch
+++ b/patch/sqlite3_fileio_init_resolve.patch
@@ -1,0 +1,31 @@
+diff --git a/shell.c b/shell.c
+index 426d589..fa64cf5 100644
+--- a/shell.c
++++ b/shell.c
+@@ -7282,7 +7282,7 @@ static int fsdirRegister(sqlite3 *db){
+ #ifdef _WIN32
+ 
+ #endif
+-int sqlite3_fileio_init(
++int sqlite3_fileio_init_default(
+   sqlite3 *db, 
+   char **pzErrMsg, 
+   const sqlite3_api_routines *pApi
+@@ -21281,7 +21281,7 @@ static void open_db(ShellState *p, int openFlags){
+     sqlite3_ieee_init(p->db, 0, 0);
+     sqlite3_series_init(p->db, 0, 0);
+ #ifndef SQLITE_SHELL_FIDDLE
+-    sqlite3_fileio_init(p->db, 0, 0);
++    sqlite3_fileio_init_default(p->db, 0, 0);
+     sqlite3_completion_init(p->db, 0, 0);
+ #endif
+ #ifdef SQLITE_HAVE_ZLIB
+@@ -23436,7 +23436,7 @@ static int arDotCommand(
+         );
+         goto end_ar_command;
+       }
+-      sqlite3_fileio_init(cmd.db, 0, 0);
++      sqlite3_fileio_init_default(cmd.db, 0, 0);
+       sqlite3_sqlar_init(cmd.db, 0, 0);
+       sqlite3_create_function(cmd.db, "shell_putsnl", 1, SQLITE_UTF8, cmd.p,
+                               shellPutsFunc, 0, 0);


### PR DESCRIPTION
Fixes the fileio extension missing functions. The fix was to rename a shell.c::sqlite3_fileio_init to a patch file. There is a duplicate function in sqlean/src/sqlite3-fileio.c which has the definition for initializing the sqlean extension.